### PR TITLE
feat(auth): reverse proxy session token validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,3 +86,58 @@ Four auth methods configured: JWT (60-min access tokens via simplejwt), Session,
 - **Networking**: The web container uses host networking (`network_mode: "host"`). It reaches PostgreSQL and Redis via `localhost` through their host port mappings (PostgreSQL on 5432, Redis on 6379). Gunicorn binds to port 8001 (port 8000 is taken by `agentconnector`).
 - **entrypoint.sh**: Waits for PostgreSQL, runs migrations, collectstatic, creates superuser if env vars set, then starts Gunicorn with 4 workers
 - **PostgreSQL compatibility**: Django is pinned to `>=5.1.6,<5.2` because the `agentconnector` container runs PostgreSQL 13 (Django 5.2+ requires PostgreSQL 14).
+
+## Reverse Proxy Session Token Validation
+
+The Django `OpenAIProxyView` validates the host application's OIDC session token before forwarding any request to the AI backend. This is the security choke point — all widget chat requests pass through here.
+
+### How it works
+
+The host application extracts its OIDC access token from `sessionStorage` and passes it as `X-LTAI-EXT-API-TOKEN` on every request. The proxy validates that token before forwarding:
+
+```
+Host App → X-LTAI-EXT-API-TOKEN header → Django proxy → validate → AI backend
+```
+
+### Key files
+
+- **`api/token_validator.py`** — core validation module. Two strategies:
+  - `jwt_local` — verifies JWT signature offline using JWKS public keys (cached 15 min). No per-request network call.
+  - `oidc_introspect` — calls RFC 7662 introspection endpoint per request. Detects revoked tokens.
+  - `none` — always passes (local dev without an OIDC provider).
+- **`api/views.py`** — `OpenAIProxyView.dispatch()` calls the validator after benchmark mode check, before UUID auth.
+
+### Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PROXY_TOKEN_VALIDATION_ENABLED` | `0` | Master switch — set to `1` to enable |
+| `PROXY_TOKEN_VALIDATION_STRATEGY` | `jwt_local` | `jwt_local`, `oidc_introspect`, or `none` |
+| `PROXY_TOKEN_VALIDATION_FAILURE_MODE` | `closed` | `closed` = reject on validator error; `open` = allow |
+| `OIDC_JWKS_URI` | — | Auth provider's JWKS public key endpoint |
+| `OIDC_JWT_ISSUER` | — | Expected `iss` claim in the token |
+| `OIDC_JWT_AUDIENCE` | — | Expected `aud` claim (optional) |
+| `OIDC_INTROSPECTION_ENDPOINT` | — | For `oidc_introspect` strategy only |
+
+### Example config (OIDC provider)
+
+```
+PROXY_TOKEN_VALIDATION_ENABLED=1
+PROXY_TOKEN_VALIDATION_STRATEGY=jwt_local
+OIDC_JWKS_URI=https://<your-auth-provider>/.well-known/jwks.json
+OIDC_JWT_ISSUER=https://<your-auth-provider>/
+```
+
+The JWKS URI can be discovered from the provider's OpenID Connect discovery document at `<issuer>/.well-known/openid-configuration`. Ensure the token signing algorithm matches a key in the JWKS (e.g. RS256).
+
+### Testing
+
+1. Obtain a valid access token from the host application's session storage
+2. `curl -s -w "\nHTTP %{http_code}" -X POST http://127.0.0.1:8001/api/openai/api/chat/completions -H "X-LTAI-EXT-API-TOKEN: <token>" -H "X-Config-Key: test" -H "Content-Type: application/json" -d '{"model":"test","messages":[{"role":"user","content":"hi"}]}'`
+3. Check `docker exec sitechime-bk-web-1 tail -10 /app/logs/security.log` for results
+
+### No-break guarantee
+
+- `PROXY_TOKEN_VALIDATION_ENABLED` defaults to `0` — existing deployments unaffected until opted in
+- Benchmark mode short-circuits before the validation gate
+- Strategy `none` available for local dev

--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,286 @@
-from django.test import TestCase
+import json
+import threading
+import time
+from unittest.mock import patch, MagicMock
 
-# Create your tests here.
+from django.test import TestCase, override_settings
+
+
+# ---------------------------------------------------------------------------
+# Helpers — generate real RSA keys so tests exercise actual crypto
+# ---------------------------------------------------------------------------
+
+def _make_rsa_key_pair():
+    """Return (private_key, public_key_jwk_dict) for test JWT signing."""
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.backends import default_backend
+    from jwt.algorithms import RSAAlgorithm
+
+    private_key = rsa.generate_private_key(
+        public_exponent=65537, key_size=2048, backend=default_backend()
+    )
+    public_key = private_key.public_key()
+    jwk_str = RSAAlgorithm.to_jwk(public_key)
+    jwk_dict = json.loads(jwk_str)
+    jwk_dict['kid'] = 'test-key-1'
+    return private_key, jwk_dict
+
+
+def _sign_jwt(private_key, payload: dict, algorithm: str = 'RS256', kid: str = 'test-key-1') -> str:
+    import jwt
+    headers = {'kid': kid} if kid else {}
+    return jwt.encode(payload, private_key, algorithm=algorithm, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# jwt_local strategy tests
+# ---------------------------------------------------------------------------
+
+class JwtLocalValidatorTests(TestCase):
+
+    def setUp(self):
+        self.private_key, self.jwk_dict = _make_rsa_key_pair()
+
+    def _mock_jwks(self):
+        return patch('api.token_validator._fetch_jwks', return_value=[self.jwk_dict])
+
+    def _valid_payload(self, offset: int = 3600) -> dict:
+        return {'sub': 'user@example.com', 'exp': int(time.time()) + offset}
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_valid_rs256_token_passes(self):
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, self._valid_payload())
+        with self._mock_jwks():
+            ok, reason = validate_ext_api_token(token)
+        self.assertTrue(ok, reason)
+        self.assertIsNone(reason)
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_expired_token_rejected(self):
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, {'sub': 'u', 'exp': int(time.time()) - 10})
+        with self._mock_jwks():
+            ok, reason = validate_ext_api_token(token)
+        self.assertFalse(ok)
+        self.assertIn('expired', reason)
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_tampered_payload_rejected(self):
+        import base64
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, self._valid_payload())
+        header, _, sig = token.split('.')
+        fake_payload = base64.urlsafe_b64encode(
+            json.dumps({'sub': 'attacker', 'exp': int(time.time()) + 9999}).encode()
+        ).rstrip(b'=').decode()
+        tampered = f"{header}.{fake_payload}.{sig}"
+        with self._mock_jwks():
+            ok, _ = validate_ext_api_token(tampered)
+        self.assertFalse(ok)
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_alg_none_rejected(self):
+        import base64
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        header = base64.urlsafe_b64encode(
+            json.dumps({'alg': 'none', 'typ': 'JWT'}).encode()
+        ).rstrip(b'=').decode()
+        payload = base64.urlsafe_b64encode(
+            json.dumps(self._valid_payload()).encode()
+        ).rstrip(b'=').decode()
+        token = f"{header}.{payload}."
+        with self._mock_jwks():
+            ok, reason = validate_ext_api_token(token)
+        self.assertFalse(ok)
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_hs256_rejected_on_jwks_path(self):
+        """
+        Critical security invariant: HS256 must be rejected when validating against JWKS.
+        Allowing HS256 enables algorithm-confusion attacks where an attacker can sign
+        a token using the RSA public key as the HMAC secret.
+        """
+        import jwt
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = jwt.encode(self._valid_payload(), 'any-secret', algorithm='HS256',
+                           headers={'kid': 'test-key-1'})
+        with self._mock_jwks():
+            ok, reason = validate_ext_api_token(token)
+        self.assertFalse(ok)
+        self.assertIn('not allowed', reason)
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        OIDC_JWKS_CACHE_TTL_SECONDS=1,
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_jwks_cache_refreshes_after_ttl(self):
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, self._valid_payload())
+        call_count = {'n': 0}
+
+        def counting_fetch(uri):
+            call_count['n'] += 1
+            return [self.jwk_dict]
+
+        with patch('api.token_validator._fetch_jwks', side_effect=counting_fetch):
+            validate_ext_api_token(token)
+            time.sleep(1.1)
+            validate_ext_api_token(token)
+
+        self.assertGreaterEqual(call_count['n'], 2, "JWKS should be re-fetched after TTL expires")
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+    )
+    def test_concurrent_cache_access_is_thread_safe(self):
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, self._valid_payload())
+        errors = []
+
+        def worker():
+            try:
+                with patch('api.token_validator._fetch_jwks', return_value=[self.jwk_dict]):
+                    ok, reason = validate_ext_api_token(token)
+                    if not ok:
+                        errors.append(f'validation failed: {reason}')
+            except Exception as exc:
+                errors.append(str(exc))
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [], f"Thread-safety errors: {errors}")
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+        PROXY_TOKEN_VALIDATION_FAILURE_MODE='closed',
+    )
+    def test_failure_mode_closed_returns_false_on_network_error(self):
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, self._valid_payload())
+        with patch('api.token_validator._fetch_jwks', side_effect=Exception("network error")):
+            ok, _ = validate_ext_api_token(token)
+        self.assertFalse(ok)
+
+    @override_settings(
+        OIDC_JWKS_URI='https://provider/.well-known/jwks.json',
+        PROXY_TOKEN_VALIDATION_STRATEGY='jwt_local',
+        PROXY_TOKEN_VALIDATION_FAILURE_MODE='open',
+    )
+    def test_failure_mode_open_returns_true_on_network_error(self):
+        from api.token_validator import validate_ext_api_token, _jwks_cache
+        _jwks_cache.clear()
+        token = _sign_jwt(self.private_key, self._valid_payload())
+        with patch('api.token_validator._fetch_jwks', side_effect=Exception("network error")):
+            ok, _ = validate_ext_api_token(token)
+        self.assertTrue(ok)
+
+
+# ---------------------------------------------------------------------------
+# none strategy tests
+# ---------------------------------------------------------------------------
+
+class NoneStrategyTests(TestCase):
+
+    @override_settings(PROXY_TOKEN_VALIDATION_STRATEGY='none')
+    def test_none_strategy_always_passes(self):
+        from api.token_validator import validate_ext_api_token
+        ok, reason = validate_ext_api_token('anything')
+        self.assertTrue(ok)
+        self.assertIsNone(reason)
+
+    @override_settings(PROXY_TOKEN_VALIDATION_STRATEGY='none')
+    def test_none_strategy_logs_warning(self):
+        from api.token_validator import validate_ext_api_token
+        with self.assertLogs('django.security', level='WARNING') as cm:
+            validate_ext_api_token('anything')
+        self.assertTrue(any('DISABLED' in line for line in cm.output))
+
+
+# ---------------------------------------------------------------------------
+# oidc_introspect strategy tests
+# ---------------------------------------------------------------------------
+
+class OidcIntrospectTests(TestCase):
+
+    @override_settings(
+        PROXY_TOKEN_VALIDATION_STRATEGY='oidc_introspect',
+        OIDC_INTROSPECTION_ENDPOINT='https://provider/introspect',
+        OIDC_CLIENT_ID='client',
+        OIDC_CLIENT_SECRET='secret',
+    )
+    def test_inactive_token_rejected(self):
+        from api.token_validator import _validate_oidc_introspect
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'active': False}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch('requests.post', return_value=mock_resp):
+            ok, reason = _validate_oidc_introspect('some-token')
+        self.assertFalse(ok)
+        self.assertIn('inactive', reason)
+
+    @override_settings(
+        PROXY_TOKEN_VALIDATION_STRATEGY='oidc_introspect',
+        OIDC_INTROSPECTION_ENDPOINT='https://provider/introspect',
+    )
+    def test_active_token_passes(self):
+        from api.token_validator import _validate_oidc_introspect
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'active': True}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch('requests.post', return_value=mock_resp):
+            ok, reason = _validate_oidc_introspect('good-token')
+        self.assertTrue(ok)
+        self.assertIsNone(reason)
+
+    @override_settings(
+        OIDC_INTROSPECTION_ENDPOINT='https://provider/introspect',
+    )
+    def test_slow_endpoint_logs_warning(self):
+        from api.token_validator import _validate_oidc_introspect
+
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {'active': True}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch('requests.post', return_value=mock_resp):
+            # Patch time.monotonic to simulate a 2.5-second response
+            with patch('api.token_validator.time') as mock_time:
+                mock_time.monotonic.side_effect = [0.0, 2.5]
+                with self.assertLogs('django.security', level='WARNING') as cm:
+                    _validate_oidc_introspect('token')
+        self.assertTrue(any('2.5s' in line for line in cm.output))

--- a/api/token_validator.py
+++ b/api/token_validator.py
@@ -6,7 +6,7 @@ Two strategies are supported, selected by PROXY_TOKEN_VALIDATION_STRATEGY:
 
   jwt_local       — Verify JWT signature + expiry locally using JWKS (no per-request network call).
   oidc_introspect — Call the OIDC token introspection endpoint (RFC 7662) per request.
-  none            — Always pass (useful for local dev with validation enabled).
+  none            — Always pass (useful for local dev with validation disabled).
 """
 
 import threading
@@ -22,7 +22,15 @@ security_logger = logging.getLogger('django.security')
 # ---------------------------------------------------------------------------
 _jwks_cache: dict = {}
 _jwks_lock = threading.Lock()
-_JWKS_TTL_SECONDS = 900  # 15 minutes
+
+# Asymmetric algorithms only — HMAC variants must NOT appear here.
+# Mixing HS256 with a JWKS public key enables the classic algorithm-confusion
+# attack where an attacker signs a token with the public key as the HMAC secret.
+_ASYMMETRIC_ALGORITHMS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512']
+
+# Configurable via OIDC_JWKS_CACHE_TTL_SECONDS (default 15 min).
+def _jwks_ttl() -> int:
+    return int(getattr(settings, 'OIDC_JWKS_CACHE_TTL_SECONDS', 900))
 
 
 def _fetch_jwks(uri: str) -> list:
@@ -38,7 +46,7 @@ def _get_jwks_keys(uri: str) -> list:
     now = time.monotonic()
     with _jwks_lock:
         entry = _jwks_cache.get(uri)
-        if entry and now - entry['fetched_at'] < _JWKS_TTL_SECONDS:
+        if entry and now - entry['fetched_at'] < _jwks_ttl():
             return entry['keys']
     # Fetch outside the lock to avoid blocking other threads during network I/O
     keys = _fetch_jwks(uri)
@@ -57,21 +65,22 @@ def _validate_jwt_local(token: str) -> tuple:
     import json as _json
 
     jwks_uri = getattr(settings, 'OIDC_JWKS_URI', '')
+    # OIDC_JWT_SECRET is for HS256 on a separate internal-only path — never
+    # used when a JWKS URI is configured (that path only accepts asymmetric algs).
     jwt_secret = getattr(settings, 'OIDC_JWT_SECRET', '')
     audience = getattr(settings, 'OIDC_JWT_AUDIENCE', None)
     issuer = getattr(settings, 'OIDC_JWT_ISSUER', None)
 
-    decode_kwargs = {
-        'algorithms': ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256'],
+    common_decode_opts = {
         # Skip audience verification when OIDC_JWT_AUDIENCE is not configured —
         # PyJWT 2.x rejects tokens that contain an aud claim unless you explicitly
         # provide the expected audience or opt out of the check.
         'options': {'verify_exp': True, 'verify_aud': bool(audience)},
     }
     if audience:
-        decode_kwargs['audience'] = audience
+        common_decode_opts['audience'] = audience
     if issuer:
-        decode_kwargs['issuer'] = issuer
+        common_decode_opts['issuer'] = issuer
 
     if jwks_uri:
         # Decode header to find the key id
@@ -80,13 +89,19 @@ def _validate_jwt_local(token: str) -> tuple:
         except _jwt.exceptions.DecodeError as exc:
             return False, f"malformed token header: {exc}"
 
+        alg = header.get('alg', 'RS256')
+        # Reject any non-asymmetric algorithm claim upfront — prevents
+        # algorithm-confusion attacks before we ever touch key material.
+        if alg not in _ASYMMETRIC_ALGORITHMS:
+            return False, f"algorithm not allowed for JWKS validation: {alg}"
+
         kid = header.get('kid')
         keys = _get_jwks_keys(jwks_uri)
 
         # Pick the matching key (or try all if no kid)
         candidates = [k for k in keys if not kid or k.get('kid') == kid]
         if not candidates:
-            # Try refreshing the cache once in case the key was rotated
+            # Refresh cache once — handles mid-rotation key rollover gracefully
             with _jwks_lock:
                 if jwks_uri in _jwks_cache:
                     del _jwks_cache[jwks_uri]
@@ -99,14 +114,13 @@ def _validate_jwt_local(token: str) -> tuple:
         last_exc = None
         for jwk in candidates:
             try:
-                alg = header.get('alg', 'RS256')
                 if alg.startswith('RS'):
                     public_key = RSAAlgorithm.from_jwk(_json.dumps(jwk))
                 elif alg.startswith('ES'):
                     public_key = ECAlgorithm.from_jwk(_json.dumps(jwk))
                 else:
                     return False, f"unsupported algorithm: {alg}"
-                _jwt.decode(token, public_key, algorithms=[alg], **{k: v for k, v in decode_kwargs.items() if k != 'algorithms'})
+                _jwt.decode(token, public_key, algorithms=[alg], **common_decode_opts)
                 return True, None
             except _jwt.exceptions.ExpiredSignatureError:
                 return False, "token expired"
@@ -119,8 +133,11 @@ def _validate_jwt_local(token: str) -> tuple:
         return False, f"signature verification failed: {last_exc}"
 
     elif jwt_secret:
+        # Separate HS256 path — only reached when no JWKS URI is configured.
+        # jwt_secret is a shared secret, not a public key, so there is no
+        # algorithm-confusion risk on this path.
         try:
-            _jwt.decode(token, jwt_secret, algorithms=['HS256'], **{k: v for k, v in decode_kwargs.items() if k != 'algorithms'})
+            _jwt.decode(token, jwt_secret, algorithms=['HS256'], **common_decode_opts)
             return True, None
         except _jwt.exceptions.ExpiredSignatureError:
             return False, "token expired"
@@ -144,12 +161,21 @@ def _validate_oidc_introspect(token: str) -> tuple:
     if not endpoint:
         return False, "OIDC_INTROSPECTION_ENDPOINT not configured"
 
+    timeout = int(getattr(settings, 'OIDC_INTROSPECTION_TIMEOUT_SECONDS', 5))
+    start = time.monotonic()
     resp = _requests.post(
         endpoint,
         data={'token': token, 'token_type_hint': 'access_token'},
         auth=(client_id, client_secret) if client_id else None,
-        timeout=5,
+        timeout=timeout,
     )
+    elapsed = time.monotonic() - start
+    if elapsed > 2:
+        security_logger.warning(
+            f"OIDC introspection endpoint took {elapsed:.1f}s — "
+            "consider switching to jwt_local strategy or increasing timeout"
+        )
+
     resp.raise_for_status()
     data = resp.json()
     if data.get('active') is True:
@@ -172,6 +198,10 @@ def validate_ext_api_token(token: str) -> tuple:
     failure_mode = getattr(settings, 'PROXY_TOKEN_VALIDATION_FAILURE_MODE', 'closed')
 
     if strategy == 'none':
+        security_logger.warning(
+            "PROXY_TOKEN_VALIDATION_STRATEGY=none — all token validation is DISABLED. "
+            "Do not use this setting in production."
+        )
         return True, None
 
     try:

--- a/api/token_validator.py
+++ b/api/token_validator.py
@@ -11,17 +11,19 @@ Two strategies are supported, selected by PROXY_TOKEN_VALIDATION_STRATEGY:
 
 import threading
 import time
-import logging
 
 from django.conf import settings
-
-security_logger = logging.getLogger('django.security')
+from utils.logger import security_logger
 
 # ---------------------------------------------------------------------------
 # JWKS cache (used by JwtLocalValidator)
 # ---------------------------------------------------------------------------
 _jwks_cache: dict = {}
 _jwks_lock = threading.Lock()
+# Per-URI refresh locks prevent a thundering herd when many concurrent requests
+# all miss on the same unknown kid — only one thread fetches while others wait.
+_jwks_fetch_locks: dict = {}
+_jwks_fetch_locks_lock = threading.Lock()
 
 # Asymmetric algorithms only — HMAC variants must NOT appear here.
 # Mixing HS256 with a JWKS public key enables the classic algorithm-confusion
@@ -71,6 +73,15 @@ def _validate_jwt_local(token: str) -> tuple:
     audience = getattr(settings, 'OIDC_JWT_AUDIENCE', None)
     issuer = getattr(settings, 'OIDC_JWT_ISSUER', None)
 
+    if not audience:
+        # Without OIDC_JWT_AUDIENCE, tokens from other services on the same issuer
+        # will be accepted (cross-service token reuse). Set OIDC_JWT_AUDIENCE in
+        # production to enforce audience binding.
+        security_logger.warning(
+            "OIDC_JWT_AUDIENCE is not configured — audience verification is disabled. "
+            "Set OIDC_JWT_AUDIENCE to prevent cross-service token acceptance."
+        )
+
     common_decode_opts = {
         # Skip audience verification when OIDC_JWT_AUDIENCE is not configured —
         # PyJWT 2.x rejects tokens that contain an aud claim unless you explicitly
@@ -101,11 +112,19 @@ def _validate_jwt_local(token: str) -> tuple:
         # Pick the matching key (or try all if no kid)
         candidates = [k for k in keys if not kid or k.get('kid') == kid]
         if not candidates:
-            # Refresh cache once — handles mid-rotation key rollover gracefully
-            with _jwks_lock:
-                if jwks_uri in _jwks_cache:
-                    del _jwks_cache[jwks_uri]
-            keys = _get_jwks_keys(jwks_uri)
+            # Refresh cache once for mid-rotation key rollover. Use a per-URI
+            # lock so only one thread fetches — others wait and reuse the result,
+            # preventing a thundering herd when many requests arrive with an
+            # unknown kid simultaneously.
+            with _jwks_fetch_locks_lock:
+                if jwks_uri not in _jwks_fetch_locks:
+                    _jwks_fetch_locks[jwks_uri] = threading.Lock()
+                fetch_lock = _jwks_fetch_locks[jwks_uri]
+            with fetch_lock:
+                with _jwks_lock:
+                    if jwks_uri in _jwks_cache:
+                        del _jwks_cache[jwks_uri]
+                keys = _get_jwks_keys(jwks_uri)
             candidates = [k for k in keys if not kid or k.get('kid') == kid]
 
         if not candidates:

--- a/api/token_validator.py
+++ b/api/token_validator.py
@@ -1,0 +1,189 @@
+"""
+Reverse proxy session token validation.
+
+Validates the X-LTAI-EXT-API-TOKEN header before forwarding requests upstream.
+Two strategies are supported, selected by PROXY_TOKEN_VALIDATION_STRATEGY:
+
+  jwt_local       — Verify JWT signature + expiry locally using JWKS (no per-request network call).
+  oidc_introspect — Call the OIDC token introspection endpoint (RFC 7662) per request.
+  none            — Always pass (useful for local dev with validation enabled).
+"""
+
+import threading
+import time
+import logging
+
+from django.conf import settings
+
+security_logger = logging.getLogger('django.security')
+
+# ---------------------------------------------------------------------------
+# JWKS cache (used by JwtLocalValidator)
+# ---------------------------------------------------------------------------
+_jwks_cache: dict = {}
+_jwks_lock = threading.Lock()
+_JWKS_TTL_SECONDS = 900  # 15 minutes
+
+
+def _fetch_jwks(uri: str) -> list:
+    """Fetch JWKS keys from URI, returning the list of key dicts."""
+    import requests as _requests
+    resp = _requests.get(uri, timeout=5)
+    resp.raise_for_status()
+    return resp.json().get('keys', [])
+
+
+def _get_jwks_keys(uri: str) -> list:
+    """Return cached JWKS keys, refreshing if the TTL has elapsed."""
+    now = time.monotonic()
+    with _jwks_lock:
+        entry = _jwks_cache.get(uri)
+        if entry and now - entry['fetched_at'] < _JWKS_TTL_SECONDS:
+            return entry['keys']
+    # Fetch outside the lock to avoid blocking other threads during network I/O
+    keys = _fetch_jwks(uri)
+    with _jwks_lock:
+        _jwks_cache[uri] = {'keys': keys, 'fetched_at': time.monotonic()}
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# Strategy: jwt_local
+# ---------------------------------------------------------------------------
+
+def _validate_jwt_local(token: str) -> tuple:
+    import jwt as _jwt
+    from jwt.algorithms import RSAAlgorithm, ECAlgorithm
+    import json as _json
+
+    jwks_uri = getattr(settings, 'OIDC_JWKS_URI', '')
+    jwt_secret = getattr(settings, 'OIDC_JWT_SECRET', '')
+    audience = getattr(settings, 'OIDC_JWT_AUDIENCE', None)
+    issuer = getattr(settings, 'OIDC_JWT_ISSUER', None)
+
+    decode_kwargs = {
+        'algorithms': ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'HS256'],
+        # Skip audience verification when OIDC_JWT_AUDIENCE is not configured —
+        # PyJWT 2.x rejects tokens that contain an aud claim unless you explicitly
+        # provide the expected audience or opt out of the check.
+        'options': {'verify_exp': True, 'verify_aud': bool(audience)},
+    }
+    if audience:
+        decode_kwargs['audience'] = audience
+    if issuer:
+        decode_kwargs['issuer'] = issuer
+
+    if jwks_uri:
+        # Decode header to find the key id
+        try:
+            header = _jwt.get_unverified_header(token)
+        except _jwt.exceptions.DecodeError as exc:
+            return False, f"malformed token header: {exc}"
+
+        kid = header.get('kid')
+        keys = _get_jwks_keys(jwks_uri)
+
+        # Pick the matching key (or try all if no kid)
+        candidates = [k for k in keys if not kid or k.get('kid') == kid]
+        if not candidates:
+            # Try refreshing the cache once in case the key was rotated
+            with _jwks_lock:
+                if jwks_uri in _jwks_cache:
+                    del _jwks_cache[jwks_uri]
+            keys = _get_jwks_keys(jwks_uri)
+            candidates = [k for k in keys if not kid or k.get('kid') == kid]
+
+        if not candidates:
+            return False, "no matching JWKS key found"
+
+        last_exc = None
+        for jwk in candidates:
+            try:
+                alg = header.get('alg', 'RS256')
+                if alg.startswith('RS'):
+                    public_key = RSAAlgorithm.from_jwk(_json.dumps(jwk))
+                elif alg.startswith('ES'):
+                    public_key = ECAlgorithm.from_jwk(_json.dumps(jwk))
+                else:
+                    return False, f"unsupported algorithm: {alg}"
+                _jwt.decode(token, public_key, algorithms=[alg], **{k: v for k, v in decode_kwargs.items() if k != 'algorithms'})
+                return True, None
+            except _jwt.exceptions.ExpiredSignatureError:
+                return False, "token expired"
+            except _jwt.exceptions.InvalidAudienceError:
+                return False, "invalid audience"
+            except _jwt.exceptions.InvalidIssuerError:
+                return False, "invalid issuer"
+            except Exception as exc:
+                last_exc = exc
+        return False, f"signature verification failed: {last_exc}"
+
+    elif jwt_secret:
+        try:
+            _jwt.decode(token, jwt_secret, algorithms=['HS256'], **{k: v for k, v in decode_kwargs.items() if k != 'algorithms'})
+            return True, None
+        except _jwt.exceptions.ExpiredSignatureError:
+            return False, "token expired"
+        except Exception as exc:
+            return False, str(exc)
+
+    return False, "no OIDC_JWKS_URI or OIDC_JWT_SECRET configured"
+
+
+# ---------------------------------------------------------------------------
+# Strategy: oidc_introspect
+# ---------------------------------------------------------------------------
+
+def _validate_oidc_introspect(token: str) -> tuple:
+    import requests as _requests
+
+    endpoint = getattr(settings, 'OIDC_INTROSPECTION_ENDPOINT', '')
+    client_id = getattr(settings, 'OIDC_CLIENT_ID', '')
+    client_secret = getattr(settings, 'OIDC_CLIENT_SECRET', '')
+
+    if not endpoint:
+        return False, "OIDC_INTROSPECTION_ENDPOINT not configured"
+
+    resp = _requests.post(
+        endpoint,
+        data={'token': token, 'token_type_hint': 'access_token'},
+        auth=(client_id, client_secret) if client_id else None,
+        timeout=5,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    if data.get('active') is True:
+        return True, None
+    return False, "token inactive or revoked"
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def validate_ext_api_token(token: str) -> tuple:
+    """
+    Validate the session token extracted from X-LTAI-EXT-API-TOKEN.
+
+    Returns (True, None) on success, (False, reason_string) on failure.
+    Never raises — exceptions are caught and handled per PROXY_TOKEN_VALIDATION_FAILURE_MODE.
+    """
+    strategy = getattr(settings, 'PROXY_TOKEN_VALIDATION_STRATEGY', 'jwt_local')
+    failure_mode = getattr(settings, 'PROXY_TOKEN_VALIDATION_FAILURE_MODE', 'closed')
+
+    if strategy == 'none':
+        return True, None
+
+    try:
+        if strategy == 'jwt_local':
+            return _validate_jwt_local(token)
+        elif strategy == 'oidc_introspect':
+            return _validate_oidc_introspect(token)
+        else:
+            security_logger.warning(f"Unknown PROXY_TOKEN_VALIDATION_STRATEGY: {strategy}")
+            return False, f"unknown strategy: {strategy}"
+    except Exception as exc:
+        security_logger.error(f"Token validator raised an unexpected error: {exc}")
+        if failure_mode == 'open':
+            return True, None
+        return False, "validator internal error"

--- a/api/views.py
+++ b/api/views.py
@@ -151,7 +151,27 @@ class OpenAIProxyView(RateLimitedProxyView):
         if benchmark_mode and request.method == 'POST':
             api_logger.info("Benchmark mode is enabled, returning static response")
             return self.get_benchmark_response(request, *args, **kwargs)
-            
+
+        # Validate session token from host application
+        if settings.PROXY_TOKEN_VALIDATION_ENABLED and settings.PROXY_TOKEN_VALIDATION_STRATEGY != 'none':
+            from .token_validator import validate_ext_api_token
+            from django.http import JsonResponse
+            raw_token = request.headers.get('X-LTAI-EXT-API-TOKEN', '').strip()
+            if not raw_token:
+                security_logger.warning(f"Proxy auth: missing X-LTAI-EXT-API-TOKEN for {request.path}")
+                return JsonResponse(
+                    {"error": "Unauthorized", "detail": "Missing session token."},
+                    status=401
+                )
+            valid, reason = validate_ext_api_token(raw_token)
+            if not valid:
+                security_logger.warning(f"Proxy auth: rejected token for {request.path}, reason={reason}")
+                return JsonResponse(
+                    {"error": "Unauthorized", "detail": "Invalid or expired session token."},
+                    status=401
+                )
+            security_logger.info(f"Proxy auth: token accepted for {request.path}")
+
         # Try to authenticate via UUID
         uuid_value = request.headers.get('X-Config-Key') or request.GET.get('uuid')
         

--- a/api/views.py
+++ b/api/views.py
@@ -153,24 +153,29 @@ class OpenAIProxyView(RateLimitedProxyView):
             return self.get_benchmark_response(request, *args, **kwargs)
 
         # Validate session token from host application
-        if settings.PROXY_TOKEN_VALIDATION_ENABLED and settings.PROXY_TOKEN_VALIDATION_STRATEGY != 'none':
+        if settings.PROXY_TOKEN_VALIDATION_ENABLED:
             from .token_validator import validate_ext_api_token
             from django.http import JsonResponse
-            raw_token = request.headers.get('X-LTAI-EXT-API-TOKEN', '').strip()
-            if not raw_token:
-                security_logger.warning(f"Proxy auth: missing X-LTAI-EXT-API-TOKEN for {request.path}")
-                return JsonResponse(
-                    {"error": "Unauthorized", "detail": "Missing session token."},
-                    status=401
-                )
-            valid, reason = validate_ext_api_token(raw_token)
-            if not valid:
-                security_logger.warning(f"Proxy auth: rejected token for {request.path}, reason={reason}")
-                return JsonResponse(
-                    {"error": "Unauthorized", "detail": "Invalid or expired session token."},
-                    status=401
-                )
-            security_logger.info(f"Proxy auth: token accepted for {request.path}")
+            if settings.PROXY_TOKEN_VALIDATION_STRATEGY == 'none':
+                # Let validate_ext_api_token handle the none strategy so the
+                # "disabled in production" warning always fires when ENABLED=1.
+                validate_ext_api_token('')
+            else:
+                raw_token = request.headers.get('X-LTAI-EXT-API-TOKEN', '').strip()
+                if not raw_token:
+                    security_logger.warning(f"Proxy auth: missing X-LTAI-EXT-API-TOKEN for {request.path}")
+                    return JsonResponse(
+                        {"error": "Unauthorized", "detail": "Missing session token."},
+                        status=401
+                    )
+                valid, reason = validate_ext_api_token(raw_token)
+                if not valid:
+                    security_logger.warning(f"Proxy auth: rejected token for {request.path}, reason={reason}")
+                    return JsonResponse(
+                        {"error": "Unauthorized", "detail": "Invalid or expired session token."},
+                        status=401
+                    )
+                security_logger.info(f"Proxy auth: token accepted for {request.path}")
 
         # Try to authenticate via UUID
         uuid_value = request.headers.get('X-Config-Key') or request.GET.get('uuid')

--- a/cloudcontrol_widget_backend/settings.py
+++ b/cloudcontrol_widget_backend/settings.py
@@ -308,3 +308,23 @@ OPENWEBUI_API_TOKEN = os.environ.get('OPENWEBUI_API_TOKEN')
 # Benchmark mode for testing
 # When set to 1, OpenAIProxyView will return static responses instead of making real API calls
 BENCHMARK_MODE = os.environ.get('BENCHMARK_MODE', '0') == '1'
+
+# Reverse proxy session token validation
+# Set PROXY_TOKEN_VALIDATION_ENABLED=1 to activate. Off by default so existing deployments are unaffected.
+PROXY_TOKEN_VALIDATION_ENABLED = os.environ.get('PROXY_TOKEN_VALIDATION_ENABLED', '0') == '1'
+# Strategy: "jwt_local" (verify JWT signature locally using JWKS),
+#           "oidc_introspect" (call OIDC introspection endpoint per request),
+#           "none" (always pass — for local dev with validation enabled)
+PROXY_TOKEN_VALIDATION_STRATEGY = os.environ.get('PROXY_TOKEN_VALIDATION_STRATEGY', 'jwt_local')
+# "closed" = reject on validator error (safe default), "open" = allow on error
+PROXY_TOKEN_VALIDATION_FAILURE_MODE = os.environ.get('PROXY_TOKEN_VALIDATION_FAILURE_MODE', 'closed')
+
+# OIDC / JWT settings (used by token_validator.py)
+OIDC_JWKS_URI = os.environ.get('OIDC_JWKS_URI', '')
+OIDC_JWT_SECRET = os.environ.get('OIDC_JWT_SECRET', '')  # HS256 fallback (dev/test only)
+OIDC_JWT_AUDIENCE = [a.strip() for a in os.environ.get('OIDC_JWT_AUDIENCE', '').split(',') if a.strip()] or None
+OIDC_JWT_ISSUER = os.environ.get('OIDC_JWT_ISSUER', '') or None
+
+OIDC_INTROSPECTION_ENDPOINT = os.environ.get('OIDC_INTROSPECTION_ENDPOINT', '')
+OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID', '')
+OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET', '')

--- a/cloudcontrol_widget_backend/settings.py
+++ b/cloudcontrol_widget_backend/settings.py
@@ -321,10 +321,18 @@ PROXY_TOKEN_VALIDATION_FAILURE_MODE = os.environ.get('PROXY_TOKEN_VALIDATION_FAI
 
 # OIDC / JWT settings (used by token_validator.py)
 OIDC_JWKS_URI = os.environ.get('OIDC_JWKS_URI', '')
-OIDC_JWT_SECRET = os.environ.get('OIDC_JWT_SECRET', '')  # HS256 fallback (dev/test only)
+# OIDC_JWT_SECRET: shared secret for HS256 validation on an internal-only path.
+# This is ONLY used when OIDC_JWKS_URI is NOT set. When a JWKS URI is configured,
+# the jwt_local strategy uses asymmetric algorithms exclusively and this value is ignored.
+# Do NOT use for OIDC provider tokens — use OIDC_JWKS_URI for that.
+OIDC_JWT_SECRET = os.environ.get('OIDC_JWT_SECRET', '')
 OIDC_JWT_AUDIENCE = [a.strip() for a in os.environ.get('OIDC_JWT_AUDIENCE', '').split(',') if a.strip()] or None
 OIDC_JWT_ISSUER = os.environ.get('OIDC_JWT_ISSUER', '') or None
+# How long to cache JWKS keys before re-fetching (seconds). Default: 900 (15 min).
+OIDC_JWKS_CACHE_TTL_SECONDS = int(os.environ.get('OIDC_JWKS_CACHE_TTL_SECONDS', 900))
 
 OIDC_INTROSPECTION_ENDPOINT = os.environ.get('OIDC_INTROSPECTION_ENDPOINT', '')
+# Timeout in seconds for the OIDC introspection endpoint request. Default: 5.
+OIDC_INTROSPECTION_TIMEOUT_SECONDS = int(os.environ.get('OIDC_INTROSPECTION_TIMEOUT_SECONDS', 5))
 OIDC_CLIENT_ID = os.environ.get('OIDC_CLIENT_ID', '')
 OIDC_CLIENT_SECRET = os.environ.get('OIDC_CLIENT_SECRET', '')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,27 @@
 version: '3.8'
 
 services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    network_mode: "host"
+    environment:
+      POSTGRES_DB: cloudcontrol
+      POSTGRES_USER: cloudcontrol_user
+      POSTGRES_PASSWORD: cloudcontrol2024
+    volumes:
+      - sitechime_pgdata:/var/lib/postgresql/data
+    command: -p 5434
+
   web:
     build: .
     network_mode: "host"
+    depends_on:
+      - db
     volumes:
       - ./logs:/app/logs
     env_file:
       - .env
+
+volumes:
+  sitechime_pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     restart: unless-stopped
     network_mode: "host"
     environment:
-      POSTGRES_DB: cloudcontrol
-      POSTGRES_USER: cloudcontrol_user
-      POSTGRES_PASSWORD: cloudcontrol2024
+      POSTGRES_DB: ${POSTGRES_DB:-cloudcontrol}
+      POSTGRES_USER: ${POSTGRES_USER:-cloudcontrol_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
     volumes:
       - sitechime_pgdata:/var/lib/postgresql/data
     command: -p 5434

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ django-cors-headers>=4.3.1
 gunicorn>=21.2.0
 PyYAML>=6.0
 requests>=2.31.0
+PyJWT>=2.8.0
+cryptography>=41.0.0


### PR DESCRIPTION
## Summary

- Validates the host application's OIDC session token at the Django reverse proxy layer before forwarding requests to the AI backend
- Off by default (`PROXY_TOKEN_VALIDATION_ENABLED=0`) — zero impact on existing deployments until opted in
- Two validation strategies: `jwt_local` (offline JWKS signature check, 15-min cache) and `oidc_introspect` (per-request RFC 7662 check)

## Changes

- `api/token_validator.py` — new validation module with JWKS caching and two strategies
- `api/views.py` — validation gate in `OpenAIProxyView.dispatch()` before proxying
- `settings.py` — `PROXY_TOKEN_VALIDATION_*` and `OIDC_*` env vars
- `requirements.txt` — `PyJWT>=2.8.0`, `cryptography>=41.0.0`
- `docker-compose.yml` — postgres service for local dev
- `CLAUDE.md` — configuration and testing documentation

## Test plan

- [ ] `PROXY_TOKEN_VALIDATION_ENABLED=0` — existing flows unaffected
- [ ] `PROXY_TOKEN_VALIDATION_ENABLED=1`, no token in request → `401 Missing session token`
- [ ] Valid OIDC token → passes through to AI backend
- [ ] Expired or tampered token → `401 Invalid or expired session token`
- [ ] Check `docker exec sitechime-bk-web-1 tail -10 /app/logs/security.log` for rejection reasons (no token values logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)